### PR TITLE
Changing selector 'contains' to use option :text to find elements.

### DIFF
--- a/lib/capybara-select2.rb
+++ b/lib/capybara-select2.rb
@@ -2,17 +2,16 @@ require "capybara-select2/version"
 
 module Capybara
   module Select2
-    def select2(value, options={})
+    def select2(value, options = {})
       raise "Must pass a hash containing 'from'" if not options.is_a?(Hash) or not options.has_key?(:from)
       select_name = options[:from]
 
-      select2_container=find("label:contains(\"#{select_name}\")").find(:xpath, '..').find(".select2-container")
+      select2_container=find("label", text: select_name).find(:xpath, '..').find(".select2-container")
       PP.pp(select2_container)
 
       select2_container.find(".select2-choice").click
 
-      find(".select2-drop li:contains(\"#{value}\")").click
-
+      find(".select2-drop li", text: value).click
     end
   end
 end


### PR DESCRIPTION
This change has been based on Capybara documentation.

http://rubydoc.info/github/jnicklas/capybara/master/Capybara/Node/Finders#find-instance_method
