### PR TITLE
add select2 multiple choices support

### DIFF
--- a/lib/capybara-select2.rb
+++ b/lib/capybara-select2.rb
@@ -8,9 +8,11 @@ module Capybara
       select_name = options[:from]
 
       select2_container=first("label", text: select_name).find(:xpath, '..').find(".select2-container")
-      select2_container.find(".select2-choice").click
 
-      find(:xpath, "//body").find(".select2-drop li", text: value).click
+      [value].flatten.each do |value|
+        select2_container.find(:xpath, "a[contains(concat(' ',normalize-space(@class),' '),' select2-choice ')] | ul[contains(concat(' ',normalize-space(@class),' '),' select2-choices ')]").click
+        find(:xpath, "//body").find(".select2-drop li", text: value).click
+      end
     end
   end
 end


### PR DESCRIPTION
I needed select2 multiple choices support, so I share my changes with you.

Usage :
Just use the method like before : select2("Dropdown Text", from: "Label of the dropdown")
Or with multiples choices in an array : select2(["Choice 1", "Choice 2"], from: "Label of the dropdown").
