### PR TITLE
add xpath selector feature for select2 container

### DIFF
--- a/lib/capybara-select2.rb
+++ b/lib/capybara-select2.rb
@@ -4,10 +4,15 @@ require 'rspec/core'
 module Capybara
   module Select2
     def select2(value, options = {})
-      raise "Must pass a hash containing 'from'" if not options.is_a?(Hash) or not options.has_key?(:from)
-      select_name = options[:from]
+      raise "Must pass a hash containing 'from' or 'xpath'" unless options.is_a?(Hash) and [:from, :xpath].any? { |k| options.has_key? k }
 
-      select2_container=first("label", text: select_name).find(:xpath, '..').find(".select2-container")
+      if options.has_key? :xpath
+        select2_container = first(:xpath, options[:xpath])
+      else
+        select_name = options[:from]
+        select2_container = first("label", text: select_name).find(:xpath, '..').find(".select2-container")
+      end
+
       select2_container.find(".select2-choice").click
 
       find(:xpath, "//body").find(".select2-drop li", text: value).click


### PR DESCRIPTION
I have some select2 without label in my forms. So I needed to find their container by id. These ids are sometimes quite complex (eg. : s2id_product_prices_attributes_1369207263564_currency_id), so call them with xPath syntax is really usefull in these cases.

With my changes, it's now possible to use this syntax : 
select2("Dropdown Text", xpath: ".//path_to//the_dropdown_container")

this patch can easily be used with my previous one (select2-multiple)
