### PR TITLE
Add support for select multiple choices field

### DIFF
--- a/gem/lib/capybara-select2.rb
+++ b/gem/lib/capybara-select2.rb
@@ -13,7 +13,12 @@ module Capybara
         select2_container = first("label", text: select_name).find(:xpath, '..').find(".select2-container")
       end
 
-      select2_container.find(".select2-choice").click
+      # Open select2 field
+      if select2_container.has_selector?(".select2-choice")
+        select2_container.find(".select2-choice").click
+      else
+        select2_container.find(".select2-choices").click
+      end
 
       if options.has_key? :search
         find(:xpath, "//body").find("input.select2-input").set(value)


### PR DESCRIPTION
This change check first if the select2-container has a ".select2-choice" or ".select2-choices" css definition.

I had to implement this because my select2 multiple select field had instead of ".select2-choice" a ".select2-choices" css definition, and with this code it works.
