### PR TITLE
fix 'Unable to find css ".select2-drop li" with text "Apple"'

### DIFF
--- a/gem/lib/capybara-select2.rb
+++ b/gem/lib/capybara-select2.rb
@@ -24,7 +24,6 @@ module Capybara
       end
 
       [value].flatten.each do |value|
-        select2_container.find(:xpath, "a[contains(concat(' ',normalize-space(@class),' '),' select2-choice ')] | ul[contains(concat(' ',normalize-space(@class),' '),' select2-choices ')]").click
         find(:xpath, "//body").find("#{drop_container} li", text: value).click
       end
     end


### PR DESCRIPTION
```
Capybara::ElementNotFound:
   Unable to find css ".select2-drop li" with text "Thailand"
```

Look like this line just closes the dropdown which was previously opened by 

```
select2_container.find(".select2-choice").click
```
