### PR TITLE
Add ability to select tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Or, add it into your test group
     group :test do
       gem 'capybara-select2'
       ...
-    end	
+    end
 
 And then execute:
 
@@ -38,6 +38,12 @@ or
 If the select2 field has a `min_length` option (acts as a search field) specify it with:
 
     select2("foo", from: "Label of the dropdown", search: true)
+
+If select2 field has [tags](http://ivaynberg.github.io/select2/#tags) option you can use:
+
+```ruby
+select2_tag('value', from: 'Label of input')
+```
 
 ## Contributing
 

--- a/gem/lib/capybara-select2.rb
+++ b/gem/lib/capybara-select2.rb
@@ -1,4 +1,5 @@
 require "capybara-select2/version"
+require 'capybara/selectors/tag_selector'
 require 'rspec/core'
 
 module Capybara
@@ -30,6 +31,7 @@ module Capybara
   end
 end
 
-RSpec.configure do |c|
-  c.include Capybara::Select2
+RSpec.configure do |config|
+  config.include Capybara::Select2
+  config.include Capybara::Selectors::TagSelector
 end

--- a/gem/lib/capybara/selectors/tag_selector.rb
+++ b/gem/lib/capybara/selectors/tag_selector.rb
@@ -1,0 +1,15 @@
+module Capybara
+  module Selectors
+    module TagSelector
+      def select2_tag(value, options = {})
+        if options[:from]
+          find(:fillable_field, options[:from]).set(value)
+        else
+          find('input.select2-input').set(value)
+        end
+
+        find('.select2-drop li', text: value).click
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hey, 

I've added ability to select [tags](http://ivaynberg.github.io/select2/#tags) from select2. 

Instead of making `select2` a God-Method I'm suggesting to use separate method `select2_tag` :) 
If you agree with this convention I can split `select2` and `select2` with `search` field and add tests in next PR.
