### PR TITLE
Add support for lists with `<optgroup>`'s

### DIFF
--- a/gem/lib/capybara-select2.rb
+++ b/gem/lib/capybara-select2.rb
@@ -27,7 +27,7 @@ module Capybara
       end
 
       [value].flatten.each do |value|
-        find(:xpath, "//body").find("#{drop_container} li", text: value).click
+        find(:xpath, "//body").find("#{drop_container} li.select2-result-selectable", text: value).click
       end
     end
   end

--- a/gem/lib/capybara-select2/version.rb
+++ b/gem/lib/capybara-select2/version.rb
@@ -1,5 +1,5 @@
 module Capybara
   module Select2
-    VERSION = "1.0.0"
+    VERSION = "1.0.1"
   end
 end


### PR DESCRIPTION
When translating a list with `<optgroup>`'s select2 will use the
following structue:

```
div.select2-drop
  ul.select2-results
    li.select2-result.select2-result-unselectable
      div
      ul.select2-result-stub
        li.select2-result.select2-result-selectable
        li.select2-result.select2-result-selectable
        ...
    li.select2-result.select2-result-unselectable
    ...
```

The old `"#{drop_container} li"` selector would lead to
`Capybara::Ambiguous` error complaining that:

Ambiguous match, found 2 elements matching css ".select2-drop li" with
text "..." 

because of the additional `<li>` at the optgroup level.

This change adds a selector for `"select2-result-selectable"` to
ignore such headers.
