### PR TITLE
speed up selector for multi select2

### DIFF
--- a/gem/lib/capybara-select2.rb
+++ b/gem/lib/capybara-select2.rb
@@ -17,11 +17,7 @@ module Capybara
       end
 
       # Open select2 field
-      if select2_container.has_selector?(".select2-choice")
-        select2_container.find(".select2-choice").click
-      else
-        select2_container.find(".select2-choices").click
-      end
+      select2_container.first(".select2-choice, .select2-choices").click
 
       if options.has_key? :search
         find(:xpath, "//body").find(".select2-with-searchbox input.select2-input").set(value)


### PR DESCRIPTION
In case the select2 component is a multi select field, `select2_container.has_selector?(".select2-choice")` takes `Capybara.default_wait_time` seconds to complete. We should use non-waiting finders like `#first` instead.
