### PR TITLE
use find instead of first to support waiting

### DIFF
--- a/gem/lib/capybara-select2.rb
+++ b/gem/lib/capybara-select2.rb
@@ -8,12 +8,12 @@ module Capybara
       raise "Must pass a hash containing 'from' or 'xpath' or 'css'" unless options.is_a?(Hash) and [:from, :xpath, :css].any? { |k| options.has_key? k }
 
       if options.has_key? :xpath
-        select2_container = first(:xpath, options[:xpath])
+        select2_container = find(:xpath, options[:xpath])
       elsif options.has_key? :css
-        select2_container = first(:css, options[:css])
+        select2_container = find(:css, options[:css])
       else
         select_name = options[:from]
-        select2_container = first("label", text: select_name).find(:xpath, '..').find(".select2-container")
+        select2_container = find("label", text: select_name).find(:xpath, '..').find(".select2-container")
       end
 
       # Open select2 field


### PR DESCRIPTION
otherwise selecting anything during a slow run may fail

At OpenProject we have some specs involving select2 which keep [failing](https://travis-ci.org/opf/openproject/jobs/81549041) randomly. We think it's due to `capybara-select2` using `first` instead of `find`. This always works locally where it's fast. But in potentially slow runs (e.g. on travis) it fails every now and then.

Was there a specific reason you chose `first` over `find` here or do you think one could just use `find` to sovle our problems?

We're still waiting for the latest CI results to be able to confirm if this change helped us or not.
Will update.