### PR TITLE
Use `match: :first` after changing first to find

### DIFF
--- a/gem/lib/capybara-select2.rb
+++ b/gem/lib/capybara-select2.rb
@@ -8,12 +8,12 @@ module Capybara
       raise "Must pass a hash containing 'from' or 'xpath' or 'css'" unless options.is_a?(Hash) and [:from, :xpath, :css].any? { |k| options.has_key? k }
 
       if options.has_key? :xpath
-        select2_container = find(:xpath, options[:xpath])
+        select2_container = find(:xpath, options[:xpath], match: :first)
       elsif options.has_key? :css
-        select2_container = find(:css, options[:css])
+        select2_container = find(:css, options[:css], match: :first)
       else
         select_name = options[:from]
-        select2_container = find("label", text: select_name).find(:xpath, '..').find(".select2-container")
+        select2_container = find("label", text: select_name, match: :first).find(:xpath, '..').find(".select2-container")
       end
 
       # Open select2 field


### PR DESCRIPTION
In #37 we changed the `first()` to `find()` but this leads to #41. This is a fix for the same.
