### PR TITLE
Add treeitem to option selector (optgroup support)

### DIFF
--- a/gem/lib/capybara-select2.rb
+++ b/gem/lib/capybara-select2.rb
@@ -40,7 +40,7 @@ module Capybara
       [value].flatten.each do |value|
         if find(:xpath, "//body").has_selector?("#{drop_container} li.select2-results__option")
           # select2 version 4.0
-          find(:xpath, "//body").find("#{drop_container} li.select2-results__option", text: value).click
+          find(:xpath, "//body").find("#{drop_container} li.select2-results__option[role='treeitem']", text: value).click
         else
           find(:xpath, "//body").find("#{drop_container} li.select2-result-selectable", text: value).click
         end


### PR DESCRIPTION
There is an issue with optgroups because the labels of the optgroups also have the class `select2-results__option`. Adding the role to the selector fixes this issue.

More details about the issue here.
https://github.com/goodwill/capybara-select2/issues/46
