### PR TITLE
Don't depend on RSpec

### DIFF
--- a/gem/capybara-select2.gemspec
+++ b/gem/capybara-select2.gemspec
@@ -17,6 +17,5 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
   
-  gem.add_dependency 'rspec'
   gem.add_dependency 'capybara'
 end

--- a/gem/lib/capybara-select2.rb
+++ b/gem/lib/capybara-select2.rb
@@ -1,6 +1,5 @@
 require "capybara-select2/version"
 require 'capybara/selectors/tag_selector'
-require 'rspec/core'
 
 module Capybara
   module Select2
@@ -49,7 +48,12 @@ module Capybara
   end
 end
 
-RSpec.configure do |config|
-  config.include Capybara::Select2
-  config.include Capybara::Selectors::TagSelector
+begin
+  require 'rspec/core'
+
+  RSpec.configure do |config|
+    config.include Capybara::Select2
+    config.include Capybara::Selectors::TagSelector
+  end
+rescue LoadError
 end


### PR DESCRIPTION
Not all projects that use capybara and select2 use RSpec, and we shouldn't automatically add the rspec gem to those projects.

Adding `capybara-select2` to my project broke some of my Minitest tests, simply by loading RSpec into the Ruby interpreter.

We can still configure RSpec support automatically, but only need to run that code if RSpec is available.
