### PR TITLE
[FIX] Ambiguous match for .select2-search input.select2-search__field

### DIFF
--- a/gem/lib/capybara-select2.rb
+++ b/gem/lib/capybara-select2.rb
@@ -27,8 +27,8 @@ module Capybara
       end
 
       if options.has_key? :search
-        find(:xpath, "//body").find(".select2-search input.select2-search__field").set(value)
-        page.execute_script(%|$("input.select2-search__field:visible").keyup();|)
+        find(:xpath, "//body").find(".select2-container--open input.select2-search__field").set(value)
+        page.execute_script(%|$(".select2-container--open  input.select2-search__field:visible").keyup();|)
         drop_container = ".select2-results"
       elsif find(:xpath, "//body").has_selector?(".select2-dropdown")
         # select2 version 4.0


### PR DESCRIPTION
Fixing Ambiguous match for ".select2-search input.select2-search__field" when the page have multiple  select2 fields that work with ajax and tags enabled.
