### PR TITLE
Fix select2 version 4 support to handle grouped options

### DIFF
--- a/gem/lib/capybara-select2.rb
+++ b/gem/lib/capybara-select2.rb
@@ -38,9 +38,9 @@ module Capybara
       end
 
       [value].flatten.each do |value|
-        if find(:xpath, "//body").has_selector?("#{drop_container} li.select2-results__option")
+        if find(:xpath, "//body").has_selector?("#{drop_container} li.select2-results__option[role$=group]")
           # select2 version 4.0
-          find(:xpath, "//body").find("#{drop_container} li.select2-results__option", text: value).click
+          find(:xpath, "//body").find("#{drop_container} li.select2-results__option[role$=group]", text: value).click
         else
           find(:xpath, "//body").find("#{drop_container} li.select2-result-selectable", text: value).click
         end


### PR DESCRIPTION
When options are grouped, their group has the class select2-results__option, and the attribute role=group.
Absent this fix, that means selections against grouped fields result in:

```
Capybara::Ambiguous:
  Ambiguous match, found 2 elements matching visible css ".select2-dropdown li.select2-results__option" with text "TEXT" within #<Capybara::Node::Element tag="body" path="/html/body">
```

The fix is to exclude the group options on lookup.